### PR TITLE
Add special cases for WPI commands that are executed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 
 group = 'com.dacubeking'
-version = '2.0.0-beta.3'
+version = '2.0.0-beta.6'
 repositories {
     // Use Maven Central for resolving dependencies.
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 
 group = 'com.dacubeking'
-version = '1.0.2-beta'
+version = '2.0.0-beta.3'
 repositories {
     // Use Maven Central for resolving dependencies.
     mavenCentral()
@@ -36,6 +36,15 @@ dependencies {
 
     implementation 'org.msgpack:jackson-dataformat-msgpack:0.9.3'
 
+    implementation wpi.java.vendor.java()
+
+    nativeDebug wpi.java.deps.wpilibJniDebug(wpi.platforms.desktop)
+    nativeDebug wpi.java.vendor.jniDebug(wpi.platforms.desktop)
+    simulationDebug wpi.sim.enableDebug()
+
+    nativeRelease wpi.java.deps.wpilibJniRelease(wpi.platforms.desktop)
+    nativeRelease wpi.java.vendor.jniRelease(wpi.platforms.desktop)
+    simulationRelease wpi.sim.enableRelease()
 
 }
 

--- a/src/main/java/com/dacubeking/AutoBuilder/robot/GuiAuto.java
+++ b/src/main/java/com/dacubeking/AutoBuilder/robot/GuiAuto.java
@@ -11,6 +11,8 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -22,8 +24,9 @@ import static com.dacubeking.AutoBuilder.robot.robotinterface.AutonomousContaine
 
 public class GuiAuto implements Runnable {
 
-    private Autonomous autonomous;
-    private Pose2d initialPose;
+    private final Autonomous doNothingAutonomous = new Autonomous(new ArrayList<>());
+    private @NotNull Autonomous autonomous = doNothingAutonomous; // default to do nothing in case of some error
+    private @Nullable Pose2d initialPose;
 
     /**
      * Ensure you are creating the objects for your auto on robot init. The roborio will take multiple seconds to initialize the auto.
@@ -45,6 +48,7 @@ public class GuiAuto implements Runnable {
             autonomous = (Autonomous) Serializer.deserialize(autonomousJson, Autonomous.class, true);
         } catch (IOException e) {
             DriverStation.reportError("Failed to deserialize auto. " + e.getMessage(), e.getStackTrace());
+            // The do nothing auto will be used
         }
         init();
     }
@@ -75,6 +79,11 @@ public class GuiAuto implements Runnable {
             DriverStation.reportError("Uncaught exception in auto thread: " + e.getMessage(), e.getStackTrace());
             getCommandTranslator().stopRobot();
         });
+
+        if (autonomous == doNothingAutonomous) {
+            DriverStation.reportError("No auto was loaded. Doing nothing.", false);
+            return;
+        }
 
         AutonomousContainer.getInstance().printDebug("Started Running: " + Timer.getFPGATimestamp());
 

--- a/src/main/java/com/dacubeking/AutoBuilder/robot/GuiAuto.java
+++ b/src/main/java/com/dacubeking/AutoBuilder/robot/GuiAuto.java
@@ -24,8 +24,8 @@ import static com.dacubeking.AutoBuilder.robot.robotinterface.AutonomousContaine
 
 public class GuiAuto implements Runnable {
 
-    private final Autonomous doNothingAutonomous = new Autonomous(new ArrayList<>());
-    private @NotNull Autonomous autonomous = doNothingAutonomous; // default to do nothing in case of some error
+    private static final Autonomous DO_NOTHING_AUTONOMOUS = new Autonomous(new ArrayList<>());
+    private @NotNull Autonomous autonomous = DO_NOTHING_AUTONOMOUS; // default to do nothing in case of some error
     private @Nullable Pose2d initialPose;
 
     /**
@@ -80,7 +80,7 @@ public class GuiAuto implements Runnable {
             getCommandTranslator().stopRobot();
         });
 
-        if (autonomous == doNothingAutonomous) {
+        if (autonomous == DO_NOTHING_AUTONOMOUS) {
             DriverStation.reportError("No auto was loaded. Doing nothing.", false);
             return;
         }

--- a/src/main/java/com/dacubeking/AutoBuilder/robot/reflection/ReflectionClassData.java
+++ b/src/main/java/com/dacubeking/AutoBuilder/robot/reflection/ReflectionClassData.java
@@ -3,6 +3,7 @@ package com.dacubeking.AutoBuilder.robot.reflection;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.wpi.first.wpilibj2.command.Command;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -38,7 +39,14 @@ final class ReflectionClassData {
             this.fieldTypes[i] = clazz.getDeclaredFields()[i].getType().getName();
         }
 
-        this.superClass = clazz.getSuperclass().getName();
+        @Nullable Class<?> superClass = clazz.getSuperclass();
+        if (superClass != null) {
+            this.superClass = superClass.getName();
+        } else {
+            this.superClass = "";
+        }
+
+
         interfaces = Arrays.stream(clazz.getInterfaces()).map(Class::getName).toArray(String[]::new);
 
         modifiers = clazz.getModifiers();

--- a/src/main/java/com/dacubeking/AutoBuilder/robot/reflection/ReflectionClassData.java
+++ b/src/main/java/com/dacubeking/AutoBuilder/robot/reflection/ReflectionClassData.java
@@ -1,6 +1,7 @@
 package com.dacubeking.AutoBuilder.robot.reflection;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import edu.wpi.first.wpilibj2.command.Command;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Method;
@@ -13,9 +14,14 @@ final class ReflectionClassData {
     @JsonProperty private final String @NotNull [] fieldNames;
     @JsonProperty private final String @NotNull [] fieldTypes;
     @JsonProperty private final ReflectionMethodData @NotNull [] methods;
+
+    @JsonProperty
+    private final @NotNull String superClass;
+
+    @JsonProperty private final String @NotNull [] interfaces;
     @JsonProperty private final int modifiers;
     @JsonProperty private final boolean isEnum;
-
+    @JsonProperty private final boolean isCommand;
 
     ReflectionClassData(@NotNull Class<?> clazz) {
         this.fullName = clazz.getName();
@@ -32,19 +38,45 @@ final class ReflectionClassData {
             this.fieldTypes[i] = clazz.getDeclaredFields()[i].getType().getName();
         }
 
-        this.isEnum = clazz.isEnum();
+        this.superClass = clazz.getSuperclass().getName();
+        interfaces = Arrays.stream(clazz.getInterfaces()).map(Class::getName).toArray(String[]::new);
 
         modifiers = clazz.getModifiers();
+        this.isEnum = clazz.isEnum();
+
+        isCommand = isCommand(clazz);
+    }
+
+    private boolean isCommand(Class<?> clazz) {
+        if (clazz == null) {
+            return false;
+        }
+
+        if (clazz.getName().equals(Command.class.getName())) {
+            return true;
+        }
+
+        for (Class<?> anInterface : clazz.getInterfaces()) {
+            if (isCommand(anInterface)) {
+                return true;
+            }
+        }
+
+        return isCommand(clazz.getSuperclass());
     }
 
     @Override
-    public @NotNull
-    String toString() {
+    public String toString() {
         return "ReflectionClassData{" +
                 "fullName='" + fullName + '\'' +
                 ", fieldNames=" + Arrays.toString(fieldNames) +
                 ", fieldTypes=" + Arrays.toString(fieldTypes) +
                 ", methods=" + Arrays.toString(methods) +
+                ", superClass='" + superClass + '\'' +
+                ", interfaces=" + Arrays.toString(interfaces) +
+                ", modifiers=" + modifiers +
+                ", isEnum=" + isEnum +
+                ", isCommand=" + isCommand +
                 '}';
     }
 }

--- a/src/main/java/com/dacubeking/AutoBuilder/robot/serialization/Autonomous.java
+++ b/src/main/java/com/dacubeking/AutoBuilder/robot/serialization/Autonomous.java
@@ -15,7 +15,7 @@ public class Autonomous {
     private final List<AbstractAutonomousStep> autonomousSteps;
 
     @JsonCreator
-    private Autonomous(@JsonProperty(required = true, value = "autonomousSteps") List<AbstractAutonomousStep> autonomousSteps) {
+    public Autonomous(@JsonProperty(required = true, value = "autonomousSteps") List<AbstractAutonomousStep> autonomousSteps) {
         this.autonomousSteps = autonomousSteps;
     }
 

--- a/src/main/java/com/dacubeking/AutoBuilder/robot/serialization/TrajectoryAutonomousStep.java
+++ b/src/main/java/com/dacubeking/AutoBuilder/robot/serialization/TrajectoryAutonomousStep.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.math.trajectory.Trajectory.State;
+import edu.wpi.first.wpilibj.Timer;
 import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.NotNull;
 
@@ -19,6 +20,7 @@ import static com.dacubeking.AutoBuilder.robot.robotinterface.AutonomousContaine
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Internal
 public class TrajectoryAutonomousStep extends AbstractAutonomousStep {
+    public static final double PERIOD_TIME_S = 0.02;
     private final @NotNull Trajectory trajectory;
     private final @NotNull List<TimedRotation> rotations;
 
@@ -63,6 +65,7 @@ public class TrajectoryAutonomousStep extends AbstractAutonomousStep {
 
         int rotationIndex = 1; // Start at the second rotation (the first is the starting rotation)
         while (!getCommandTranslator().isTrajectoryDone()) { // Wait till the auto is done
+            double startTime = Timer.getFPGATimestamp();
             final double elapsedTime = getCommandTranslator().getTrajectoryElapsedTime();
 
             if (rotationIndex < rotations.size() && elapsedTime > rotations.get(rotationIndex).time) {
@@ -85,7 +88,7 @@ public class TrajectoryAutonomousStep extends AbstractAutonomousStep {
                 scriptsToExecuteByPercent.remove(0);
             }
             //noinspection BusyWait
-            Thread.sleep(10); // Throws an exception to exit if Interrupted
+            Thread.sleep((long) (1000 * Math.max(startTime + PERIOD_TIME_S - Timer.getFPGATimestamp(), 0)));
         }
         getCommandTranslator().stopRobot();
 

--- a/src/main/java/com/dacubeking/AutoBuilder/robot/serialization/command/SendableCommand.java
+++ b/src/main/java/com/dacubeking/AutoBuilder/robot/serialization/command/SendableCommand.java
@@ -14,7 +14,9 @@ import org.jetbrains.annotations.Nullable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -60,6 +62,17 @@ class SendableCommand {
         INFERABLE_TYPES_PARSER.put(Character.class.getName(), s -> Character.valueOf(s.charAt(0)));
         INFERABLE_TYPES_PARSER.put(Boolean.class.getName(), Boolean::valueOf);
     }
+
+    private static final List<String> primitiveTypes = Arrays.asList(
+            int.class.getName(),
+            double.class.getName(),
+            float.class.getName(),
+            long.class.getName(),
+            short.class.getName(),
+            byte.class.getName(),
+            char.class.getName(),
+            boolean.class.getName()
+    );
 
     @JsonCreator
     protected SendableCommand(@JsonProperty("methodName") @NotNull String methodName,
@@ -125,8 +138,12 @@ class SendableCommand {
 
                     // Get an array of the class types to find the correct method
                     Class<?>[] typeArray = new Class[argTypes.length];
-                    for (int i = 0; i < typeArray.length; i++) {
-                        typeArray[i] = Class.forName(argTypes[i]);
+                    for (int i = 0; i < objArgs.length; i++) {
+                        if (primitiveTypes.contains(argTypes[i])) {
+                            typeArray[i] = getPrimitiveClass(objArgs[i].getClass());
+                        } else {
+                            typeArray[i] = objArgs[i].getClass();
+                        }
                     }
 
                     if (typeArray.length == 0) {

--- a/src/main/java/com/dacubeking/AutoBuilder/robot/serialization/command/SendableCommand.java
+++ b/src/main/java/com/dacubeking/AutoBuilder/robot/serialization/command/SendableCommand.java
@@ -6,13 +6,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj2.command.Command;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -24,6 +25,7 @@ import static com.dacubeking.AutoBuilder.robot.robotinterface.AutonomousContaine
 @JsonIgnoreProperties(ignoreUnknown = true)
 class SendableCommand {
 
+    public static final double LOOPING_PERIOD_SECONDS = 0.02; // 50 Hz/20 ms
     @JsonProperty("methodName")
     @NotNull
     protected final String methodName;
@@ -33,6 +35,8 @@ class SendableCommand {
     @JsonProperty("argTypes") public final String[] argTypes;
 
     @JsonProperty("reflection") public final boolean reflection;
+
+    @JsonProperty("command") private final boolean command;
 
     private static final @NotNull Map<String, Function<String, Object>> INFERABLE_TYPES_PARSER;
 
@@ -61,7 +65,8 @@ class SendableCommand {
     protected SendableCommand(@JsonProperty("methodName") @NotNull String methodName,
                               @JsonProperty("args") String @NotNull [] args,
                               @JsonProperty("argTypes") String[] argTypes,
-                              @JsonProperty("reflection") boolean reflection) {
+                              @JsonProperty("reflection") boolean reflection,
+                              @JsonProperty("command") boolean command) {
         Method methodToCall = null;
         Object instance = null;
 
@@ -69,68 +74,102 @@ class SendableCommand {
         this.args = args;
         this.argTypes = argTypes;
         this.reflection = reflection;
+        this.command = command;
 
         objArgs = new Object[args.length];
 
-        for (int i = 0; i < args.length; i++) {
-            try {
-                if (INFERABLE_TYPES_PARSER.containsKey(argTypes[i])) {
-                    objArgs[i] = INFERABLE_TYPES_PARSER.get(argTypes[i]).apply(args[i]);
-                } else {
-                    objArgs[i] = Enum.valueOf(Class.forName(argTypes[i]).asSubclass(Enum.class), args[i]);
-                }
-            } catch (ClassNotFoundException e) {
-                DriverStation.reportError("Class not found: " + argTypes[i], e.getStackTrace());
-            } catch (ClassCastException e) {
-                DriverStation.reportError("Could not cast " + argTypes[i] + " to an enum", e.getStackTrace());
-            } finally {
-                if (objArgs[i] == null) { // We failed to parse the argument
-                    objArgs[i] = null;
-                }
-            }
-        }
-
-        if (reflection) {
-            String[] splitMethod = methodName.split("\\.");
-
-            String[] classNameArray = new String[splitMethod.length - 1];
-            System.arraycopy(splitMethod, 0, classNameArray, 0, classNameArray.length);
-            String className = String.join(".", classNameArray);
-
-            if (AutonomousContainer.getInstance().getAccessibleInstances().containsKey(className)) {
-                instance = AutonomousContainer.getInstance().getAccessibleInstances().get(className);
+        if (command) {
+            // If we're a command, the command name is the method name
+            if (AutonomousContainer.getInstance().getAccessibleInstances().containsKey(methodName)) {
+                instance = AutonomousContainer.getInstance().getAccessibleInstances().get(methodName);
             } else {
+                throwIllegalArgumentException("Command " + methodName + " not found. Make sure it's annotated with @AutoBuilderAccessible", null);
+            }
+            try {
+                Command castedCommand = (Command) instance; // Check that it's actually a command to prevent errors from occurring when we try to run it
+            } catch (ClassCastException e) {
+                throwIllegalArgumentException("Command " + methodName + " is not a Command. Make sure it's annotated with @AutoBuilderAccessible" +
+                        "Try rebuilding your robotCodeData.json by rerunning your robot code in simulation.", e);
+            }
+        } else {
+            for (int i = 0; i < args.length; i++) {
                 try {
-                    Class<?> cls = Class.forName(className);
-                    Class<?>[] typeArray = Arrays.stream(objArgs).sequential().map(Object::getClass).toArray(Class[]::new);
-                    if (typeArray.length == 0) {
-                        methodToCall = cls.getDeclaredMethod(splitMethod[splitMethod.length - 1]);
+                    // Parse the arguments into the correct types
+                    if (INFERABLE_TYPES_PARSER.containsKey(argTypes[i])) {
+                        // Convert the string to the correct type
+                        objArgs[i] = INFERABLE_TYPES_PARSER.get(argTypes[i]).apply(args[i]);
                     } else {
-                        methodToCall = cls.getDeclaredMethod(splitMethod[splitMethod.length - 1],
-                                Arrays.stream(objArgs).sequential().map((o) -> getPrimitiveClass(o.getClass()))
-                                        .toArray(Class<?>[]::new));
-                    }
-                    methodToCall.setAccessible(true);
-                    if (!Modifier.isStatic(methodToCall.getModifiers())) {
-                        Method getInstance = cls.getDeclaredMethod("getInstance");
-                        getInstance.setAccessible(true);
-                        instance = getInstance.invoke(null);
+                        // Convert the string to the correct enum if it's not a primitive type
+                        objArgs[i] = Enum.valueOf(Class.forName(argTypes[i]).asSubclass(Enum.class), args[i]);
                     }
                 } catch (ClassNotFoundException e) {
-                    DriverStation.reportError("Class not found: " + className + ". " + e.getMessage(), e.getStackTrace());
+                    throwIllegalArgumentException("We couldn't find the class " + argTypes[i] +
+                            ". Try rebuilding your robotCodeData.json by rerunning your robot code in simulation.", e);
+                } catch (ClassCastException e) {
+                    throwIllegalArgumentException("We couldn't cast the argument " + args[i] + " to the type " + argTypes[i] +
+                            ". Try rebuilding your robotCodeData.json by rerunning your robot code in simulation.", e);
+                } catch (NumberFormatException e) {
+                    throwIllegalArgumentException("We couldn't parse number with the type " + args[i] + " to the type " + argTypes[i] +
+                            ". Try rebuilding your robotCodeData.json by rerunning your robot code in simulation.", e);
+                }
+            }
+
+            if (reflection) {
+                String[] splitMethod = methodName.split("\\.");
+
+                String[] classNameArray = new String[splitMethod.length - 1];
+                System.arraycopy(splitMethod, 0, classNameArray, 0, classNameArray.length);
+                String className = String.join(".", classNameArray); // Get the class name that the method is in
+                try {
+                    Class<?> cls = Class.forName(className); // Get the class that the method is in
+
+                    // Get an array of the class types to find the correct method
+                    Class<?>[] typeArray = new Class[argTypes.length];
+                    for (int i = 0; i < typeArray.length; i++) {
+                        typeArray[i] = Class.forName(argTypes[i]);
+                    }
+
+                    if (typeArray.length == 0) {
+                        // If there are no arguments, just get the method with no arguments
+                        methodToCall = cls.getDeclaredMethod(splitMethod[splitMethod.length - 1]);
+                    } else {
+                        // Get the method with the correct arguments
+                        methodToCall = cls.getDeclaredMethod(splitMethod[splitMethod.length - 1], typeArray);
+                    }
+                    methodToCall.setAccessible(true); // Make the method accessible so that we can call it if it's private
+
+                    if (AutonomousContainer.getInstance().getAccessibleInstances().containsKey(className)) {
+                        // The user has specified an instance to use for this class, so use it
+                        instance = AutonomousContainer.getInstance().getAccessibleInstances().get(className);
+                    } else {
+                        if (!Modifier.isStatic(methodToCall.getModifiers())) {
+                            // If the method isn't static, we need to get an instance of the class
+                            Method getInstance = cls.getDeclaredMethod("getInstance"); // Get the getInstance method
+                            getInstance.setAccessible(true);
+                            instance = getInstance.invoke(null); // Invoke the getInstance method to get an instance of the class
+                        }
+                    }
+                } catch (ClassNotFoundException e) {
+                    throwIllegalArgumentException("Class not found: " + className + ". " + e.getMessage()
+                            + ". Try rebuilding your robotCodeData.json by rerunning your robot code in simulation.", e);
                 } catch (NoSuchMethodException e) {
-                    DriverStation.reportError(
-                            "Could not find method : " + splitMethod[splitMethod.length - 1] + " in class " + className + ". " + e.getMessage(),
-                            e.getStackTrace());
+                    throwIllegalArgumentException("Could not find method : " + splitMethod[splitMethod.length - 1] + " in class "
+                            + className + ". " + e.getMessage()
+                            + ". Try rebuilding your robotCodeData.json by rerunning your robot code in simulation.", e);
                 } catch (InvocationTargetException | IllegalAccessException e) {
-                    DriverStation.reportError("Could not get singleton reference in class " + className + " for method: " +
-                            splitMethod[splitMethod.length - 1] + ". " + e.getMessage(), e.getStackTrace());
+                    throwIllegalArgumentException("Could not get singleton reference in class " + className + " for method: " +
+                            splitMethod[splitMethod.length - 1] + ". " + e.getMessage(), e);
                 }
             }
         }
 
         this.methodToCall = methodToCall;
         this.instance = instance;
+    }
+
+    private static void throwIllegalArgumentException(@NotNull String errorMessage, @Nullable Exception e) {
+        DriverStation.reportError(errorMessage, false);
+        throw new IllegalArgumentException(errorMessage, e);
     }
 
     @JsonIgnoreProperties
@@ -171,61 +210,125 @@ class SendableCommand {
     /**
      * @throws InterruptedException            If the command fails do to an interrupt
      * @throws CommandExecutionFailedException If the command fails to execute for any other reason
-     * @throws ExecutionException              Should never happen (for some reason the future was cancelled or threw and
-     *                                         exception)
+     * @throws ExecutionException              Should never happen (for some reason the future was cancelled or threw and exception)
      */
     protected void execute() throws InterruptedException, CommandExecutionFailedException, ExecutionException {
-        if (methodToCall == null && reflection) {
-            CommandExecutionFailedException e = new CommandExecutionFailedException("Method to call is null");
-            e.fillInStackTrace();
-            throw e;
+        if (!command && methodToCall == null && reflection) {
+            throw new CommandExecutionFailedException("Method to call is null");
         }
-        if (getCommandTranslator().runOnMainThread) {
-            while (true) {
-                CompletableFuture<Object> future = new CompletableFuture<>();
-                getCommandTranslator().runOnMainThread(() -> {
-                    try {
-                        future.complete(invokeMethod());
-                    } catch (CommandExecutionFailedException | InterruptedException e) {
-                        future.complete(new UncheckedExecutionException(e));
+
+        if (command && instance == null) {
+            throw new CommandExecutionFailedException("Instance is null when calling a command");
+        }
+
+        boolean firstRun = true;
+
+        if (getCommandTranslator().runOnMainThread && reflection) {
+            try {
+                while (true) {
+                    double startTime = Timer.getFPGATimestamp(); // Time the command to keep the period constant
+
+                    CompletableFuture<Object> future = new CompletableFuture<>();
+                    final boolean finalFirstRun = firstRun;
+
+                    getCommandTranslator().runOnMainThread(() -> {
+                        try {
+                            future.complete(invokeMethod(finalFirstRun));
+                        } catch (CommandExecutionFailedException | InterruptedException e) {
+                            future.complete(new UncheckedExecutionException(e));
+                        }
+                    }); // Schedule the command to run on the main thread
+
+                    Object result = future.get(); // Wait for the command to finish
+
+                    if (result instanceof UncheckedExecutionException) { // If the command failed rethrow the exception
+                        Throwable exception = ((UncheckedExecutionException) result).getCause();
+                        if (exception instanceof InterruptedException) {
+                            throw (InterruptedException) exception;
+                        } else if (exception instanceof CommandExecutionFailedException) {
+                            throw (CommandExecutionFailedException) exception;
+                        } else {
+                            throw new CommandExecutionFailedException(
+                                    "Unexpected Exception. Please report this: " + exception.getMessage(), exception);
+                        }
                     }
-                });
 
-                Object result = future.get();
+                    if (!(result instanceof Boolean) || result.equals(true)) break; // If the command returns true or is not a boolean, stop the command
 
-                if (result instanceof UncheckedExecutionException) {
-                    Throwable exception = ((UncheckedExecutionException) result).getCause();
-                    if (exception instanceof InterruptedException) {
-                        throw (InterruptedException) exception;
-                    } else if (exception instanceof CommandExecutionFailedException) {
-                        throw (CommandExecutionFailedException) exception;
-                    } else {
-                        throw new CommandExecutionFailedException(
-                                "Unexpected Exception. Please report this: " + exception.getMessage(), exception);
+                    firstRun = false;
+                    //Keep executing the method if it returns false
+                    //noinspection BusyWait
+                    Thread.sleep((long) Math.max((LOOPING_PERIOD_SECONDS - (Timer.getFPGATimestamp() - startTime)) * 1000, 0));
+                }
+            } catch (InterruptedException e) {
+                if (command) {
+                    // If a command is interrupted, we want to end the command with the interrupted flag as true
+                    CompletableFuture<Object> future = new CompletableFuture<>();
+                    getCommandTranslator().runOnMainThread(() -> {
+                        try {
+                            Command command = (Command) instance;
+                            command.end(true);
+                            future.complete(null);
+                        } catch (Exception ex) {
+                            future.complete(ex); // If the command fails to end, we want to throw the exception
+                        }
+                    });
+                    @Nullable Object result = future.get(); // Wait for the command to finish
+                    if (result != null) {
+                        // If the command failed rethrow the exception
+                        Exception ex = (Exception) result;
+                        throw new CommandExecutionFailedException("Failed to interrupt command " + methodName + ": " + ex.getMessage(), ex);
+                    }
+                }
+                throw e; // rethrow the interrupt
+            }
+        } else {
+            try {
+                while (true) {
+                    double startTime = Timer.getFPGATimestamp();
+                    Object result = invokeMethod(firstRun);
+                    if (!(result instanceof Boolean) || result.equals(true)) break;
+                    firstRun = false;
+
+                    //Keep executing the method if it returns false
+                    //noinspection BusyWait
+                    Thread.sleep((long) Math.max((LOOPING_PERIOD_SECONDS - (Timer.getFPGATimestamp() - startTime)) * 1000, 0));
+                }
+            } catch (InterruptedException e) {
+                if (command) {
+                    // If a command is interrupted, we want to end the command with the interrupted flag as true
+                    try {
+                        ((Command) instance).end(true);
+                    } catch (Exception ex) {
+                        throw new CommandExecutionFailedException("Failed to interrupt command " + methodName + ": " + ex.getMessage(), ex);
                     }
                 }
 
-                if (!(result instanceof Boolean) || result.equals(true)) break;
-                //Keep executing the method if it returns false
-                //noinspection BusyWait
-                Thread.sleep(20);
-            }
-        } else {
-            while (true) {
-                Object result = invokeMethod();
-                if (!(result instanceof Boolean) || result.equals(true)) break;
-                //Keep executing the method if it returns false
-                //noinspection BusyWait
-                Thread.sleep(20);
+                throw e; // rethrow the interrupt
             }
         }
     }
 
-    private @Nullable Object invokeMethod() throws InterruptedException, CommandExecutionFailedException {
+    private @Nullable Object invokeMethod(boolean firstRun) throws InterruptedException, CommandExecutionFailedException {
         try {
             if (reflection) {
-                assert methodToCall != null;
-                return methodToCall.invoke(instance, objArgs);
+                if (command) {
+                    assert instance != null;
+                    Command command = (Command) instance;
+                    if (firstRun) {
+                        command.initialize();
+                    }
+                    command.execute();
+                    if (command.isFinished()) {
+                        command.end(false);
+                        return true;
+                    } else {
+                        return false;
+                    }
+                } else {
+                    assert methodToCall != null;
+                    return methodToCall.invoke(instance, objArgs); // If the method returns true & is a boolean, stop executing it
+                }
             } else {
                 switch (methodName) {
                     case "print":
@@ -238,7 +341,7 @@ class SendableCommand {
                 return null;
             }
         } catch (InterruptedException e) {
-            throw new InterruptedException("Interrupted while executing a script");
+            throw e;
         } catch (Exception e) {
             throw new CommandExecutionFailedException("Could not invoke method " + methodName + " due to: " + e.getMessage(), e);
         }

--- a/vendordeps/WPILibNewCommands.json
+++ b/vendordeps/WPILibNewCommands.json
@@ -1,0 +1,37 @@
+{
+  "fileName": "WPILibNewCommands.json",
+  "name": "WPILib-New-Commands",
+  "version": "2020.0.0",
+  "uuid": "111e20f7-815e-48f8-9dd6-e675ce75b266",
+  "mavenUrls": [],
+  "jsonUrl": "",
+  "javaDependencies": [
+      {
+          "groupId": "edu.wpi.first.wpilibNewCommands",
+          "artifactId": "wpilibNewCommands-java",
+          "version": "wpilib"
+      }
+  ],
+  "jniDependencies": [],
+  "cppDependencies": [
+      {
+          "groupId": "edu.wpi.first.wpilibNewCommands",
+          "artifactId": "wpilibNewCommands-cpp",
+          "version": "wpilib",
+          "libName": "wpilibNewCommands",
+          "headerClassifier": "headers",
+          "sourcesClassifier": "sources",
+          "sharedLibrary": true,
+          "skipInvalidPlatforms": true,
+          "binaryPlatforms": [
+              "linuxathena",
+              "linuxraspbian",
+              "linuxaarch64bionic",
+              "windowsx86-64",
+              "windowsx86",
+              "linuxx86-64",
+              "osxx86-64"
+          ]
+      }
+  ]
+}


### PR DESCRIPTION
- Depend on more of the WPI libraries
- Ensure that we don't get NPEs if we try to run an auto that failed to deserialize properly
- In ReflectionClassData, store the following extra info
  - if the method (or one of its superclasses/interfaces) implements Command
  - Its interfaces
  - It's Superclass
- Fix issues with running autos with the .auto file extension
  - Fix issues with being unable to run auto in windows when doing simulation
- Fix issues with incorrectly skipping finding the wanted method to execute if the instance for that method was an @AutoBuilderAccessible Instance
- Have non-reflection methods always run asynchronously
- When running a command (new behavior):
  - begin by running the initialize function
  - run the execute method until `isFinished` returns true
  - finish by running the end function
     - interrupted it set to true if the command is being interrupted
- Consider the execution time to ensure a consistent period in loops.