### PR TITLE
Run commands with the scheduler instead of trying to run the manually

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 
 group = 'com.dacubeking'
-version = '2.2.0-beta.8'
+version = '2.2.0-beta.13'
 repositories {
     // Use Maven Central for resolving dependencies.
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 
 group = 'com.dacubeking'
-version = '2.1.0'
+version = '2.2.0-beta.8'
 repositories {
     // Use Maven Central for resolving dependencies.
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 
 group = 'com.dacubeking'
-version = '2.0.0-wpilib2023b7'
+version = '2.1.0'
 repositories {
     // Use Maven Central for resolving dependencies.
     mavenCentral()

--- a/src/main/java/com/dacubeking/AutoBuilder/robot/annotations/AutoBuilderAccessible.java
+++ b/src/main/java/com/dacubeking/AutoBuilder/robot/annotations/AutoBuilderAccessible.java
@@ -10,12 +10,17 @@ import java.lang.annotation.Target;
 /**
  * Represents an instance of a class that Autos should have access to.
  * <p>
- * The code will automatically find singleton instances that have been a @code{getInstance} method without the use of this
- * annotation. For other instances that are not singletons, the code will automatically find the instance by searching for this
- * annotation.
+ * The code will automatically find singleton instances that have been a @code{getInstance} method without the use of this annotation. For other instances that are not singletons, the code will
+ * automatically find the instance by searching for this annotation.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD})
 public @interface AutoBuilderAccessible {
 
+    /**
+     * The name that should be used on the GUI to access this instance.
+     * <p>
+     * The allowed characters are: a-z, A-Z, 0-9, and _
+     */
+    String alias() default "";
 }

--- a/src/main/java/com/dacubeking/AutoBuilder/robot/annotations/RequireWait.java
+++ b/src/main/java/com/dacubeking/AutoBuilder/robot/annotations/RequireWait.java
@@ -21,10 +21,11 @@ import java.lang.annotation.Target;
  * <p>
  * - For Commands: This means the command will be submitted to the scheduler, but the AutoBuilder will not wait for it to finish. The CommandScheduler will run the command in the background.
  * <p>
- * - For other methods: This means the AutoBuilder will not check if the method returns true before continuing.
+ * - For other methods: This means the AutoBuilder will not check if the method returns true before continuing. Only one iteration of the method will be run.
  * <p>
- * <STRONG>NOTE:</STRONG> Only annotate classes that are commands with this annotation. If the class is not a command, the annotation will be ignored.
- * Methods can be annotated with this annotation regardless of whether or not they are commands.
+ * <STRONG>NOTE:</STRONG> Only annotate classes/fields that are commands with this annotation. If the class is not a command, the annotation will be ignored.
+ * Only methods that you're intending to run from the AutoBuilder should be annotated with this annotation. Don't annotate methods that return commands, as the AutoBuilder will not pick up the
+ * annotation. (Instead, save the returned command to a field, and annotate the field with this annotation and {@link AutoBuilderAccessible}).
  * <p>
  * Example Use Case:
  * <p>
@@ -32,7 +33,7 @@ import java.lang.annotation.Target;
  * shooter is done shooting before continuing.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
 public @interface RequireWait {
 
 }

--- a/src/main/java/com/dacubeking/AutoBuilder/robot/annotations/RequireWait.java
+++ b/src/main/java/com/dacubeking/AutoBuilder/robot/annotations/RequireWait.java
@@ -1,0 +1,38 @@
+package com.dacubeking.AutoBuilder.robot.annotations;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * This annotation should be used on methods/commands that the AutoBuilder should wait for to finish before continuing.
+ * <p>
+ * When using this annotation, the AutoBuilder will wait for the command/method to finish before continuing.
+ * <p>
+ * - For Commands: This means the command will be submitted to the scheduler, and the AutoBuilder will wait until the command finishes before continuing. The AutoBuilder will wait until
+ * {@code Command#isScheduled} returns false for the command.
+ * <p>
+ * - For other methods: This means the AutoBuilder will wait until the method returns true before continuing.
+ * <p>
+ * If a method is <STRONG>not</STRONG> annotated with this annotation, the AutoBuilder will not check if it's finished before continuing.
+ * <p>
+ * - For Commands: This means the command will be submitted to the scheduler, but the AutoBuilder will not wait for it to finish. The CommandScheduler will run the command in the background.
+ * <p>
+ * - For other methods: This means the AutoBuilder will not check if the method returns true before continuing.
+ * <p>
+ * <STRONG>NOTE:</STRONG> Only annotate classes that are commands with this annotation. If the class is not a command, the annotation will be ignored.
+ * Methods can be annotated with this annotation regardless of whether or not they are commands.
+ * <p>
+ * Example Use Case:
+ * <p>
+ * You have a shoot command/method, and you want to wait until the shooter shoots before continuing. You can annotate the shoot command with this annotation, and the AutoBuilder will wait until the
+ * shooter is done shooting before continuing.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface RequireWait {
+
+}

--- a/src/main/java/com/dacubeking/AutoBuilder/robot/reflection/ClassInformationSender.java
+++ b/src/main/java/com/dacubeking/AutoBuilder/robot/reflection/ClassInformationSender.java
@@ -53,10 +53,12 @@ public final class ClassInformationSender {
                 reflectionClassDataList.reflectionClassData.add(new ReflectionClassData(aClass));
             }
 
-            reflectionClassDataList.instanceLocations.addAll(AutonomousContainer.getInstance().getAccessibleInstances().keySet());
+            AutonomousContainer.getInstance().getAccessibleInstances().values().stream()
+                    .filter(o -> o.getClass().isAnonymousClass()) // The other instances are already in the list
+                    .forEach((value) -> reflectionClassDataList.reflectionClassData.add(new ReflectionClassData(value.getClass())));
 
             System.out.println("Found " + reflectionClassDataList.reflectionClassData.size() + " classes with "
-                    + reflectionClassDataList.instanceLocations.size() + " defined instances found.");
+                    + AutonomousContainer.getInstance().getAccessibleInstances().entrySet().size() + " annotated instances found");
 
             if (file != null) {
                 file.getParentFile().mkdir();

--- a/src/main/java/com/dacubeking/AutoBuilder/robot/reflection/ClassInformationSender.java
+++ b/src/main/java/com/dacubeking/AutoBuilder/robot/reflection/ClassInformationSender.java
@@ -55,7 +55,7 @@ public final class ClassInformationSender {
 
             AutonomousContainer.getInstance().getAccessibleInstances().values().stream()
                     .filter(o -> o.getClass().isAnonymousClass()) // The other instances are already in the list
-                    .forEach((value) -> reflectionClassDataList.reflectionClassData.add(new ReflectionClassData(value.getClass())));
+                    .forEach((value) -> reflectionClassDataList.reflectionClassData.add(new ReflectionClassData(value)));
 
             System.out.println("Found " + reflectionClassDataList.reflectionClassData.size() + " classes with "
                     + AutonomousContainer.getInstance().getAccessibleInstances().entrySet().size() + " annotated instances found");

--- a/src/main/java/com/dacubeking/AutoBuilder/robot/reflection/ReflectionClassData.java
+++ b/src/main/java/com/dacubeking/AutoBuilder/robot/reflection/ReflectionClassData.java
@@ -1,12 +1,15 @@
 package com.dacubeking.AutoBuilder.robot.reflection;
 
+import com.dacubeking.AutoBuilder.robot.robotinterface.AutonomousContainer;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj2.command.Command;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Map.Entry;
 
 final class ReflectionClassData {
     @JsonProperty
@@ -23,6 +26,9 @@ final class ReflectionClassData {
     @JsonProperty private final int modifiers;
     @JsonProperty private final boolean isEnum;
     @JsonProperty private final boolean isCommand;
+    @JsonProperty private final boolean isAnnotatedAsAccessible;
+    @JsonProperty private final String alias;
+
 
     ReflectionClassData(@NotNull Class<?> clazz) {
         this.fullName = clazz.getName();
@@ -46,13 +52,27 @@ final class ReflectionClassData {
             this.superClass = "";
         }
 
-
-        interfaces = Arrays.stream(clazz.getInterfaces()).map(Class::getName).toArray(String[]::new);
-
-        modifiers = clazz.getModifiers();
+        this.interfaces = Arrays.stream(clazz.getInterfaces()).map(Class::getName).toArray(String[]::new);
+        this.modifiers = clazz.getModifiers();
         this.isEnum = clazz.isEnum();
-
         isCommand = isCommand(clazz);
+
+        this.isAnnotatedAsAccessible = AutonomousContainer.getInstance().getAccessibleInstances().entrySet().stream()
+                .anyMatch(entry -> entry.getValue().getClass().equals(clazz));
+        if (isAnnotatedAsAccessible) {
+            this.alias = AutonomousContainer.getInstance().getAccessibleInstances().entrySet().stream()
+                    .filter(entry -> entry.getValue().getClass().equals(clazz))
+                    .map(Entry::getKey)
+                    .filter(s -> !s.equals(fullName))
+                    .findFirst()
+                    .orElse("");
+        } else {
+            this.alias = "";
+        }
+
+        if (this.alias.equals("") && clazz.isAnonymousClass()) {
+            DriverStation.reportWarning("Anonymous class found without an alias. This should be impossible. Please report this: " + clazz.getName(), false);
+        }
     }
 
     private boolean isCommand(Class<?> clazz) {
@@ -85,6 +105,8 @@ final class ReflectionClassData {
                 ", modifiers=" + modifiers +
                 ", isEnum=" + isEnum +
                 ", isCommand=" + isCommand +
+                ", isAnnotatedAsAccessible=" + isAnnotatedAsAccessible +
+                ", alias='" + alias + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/dacubeking/AutoBuilder/robot/reflection/ReflectionClassDataList.java
+++ b/src/main/java/com/dacubeking/AutoBuilder/robot/reflection/ReflectionClassDataList.java
@@ -14,8 +14,7 @@ class ReflectionClassDataList {
     }
 
     @JsonCreator
-    ReflectionClassDataList(ArrayList<ReflectionClassData> reflectionClassData,
-                            ArrayList<ReflectionClassData> instanceLocations) {
+    ReflectionClassDataList(ArrayList<ReflectionClassData> reflectionClassData) {
         this.reflectionClassData = reflectionClassData;
     }
 }

--- a/src/main/java/com/dacubeking/AutoBuilder/robot/reflection/ReflectionClassDataList.java
+++ b/src/main/java/com/dacubeking/AutoBuilder/robot/reflection/ReflectionClassDataList.java
@@ -9,17 +9,13 @@ class ReflectionClassDataList {
     @JsonProperty
     ArrayList<ReflectionClassData> reflectionClassData = new ArrayList<>();
 
-    @JsonProperty
-    ArrayList<String> instanceLocations = new ArrayList<>();
-
 
     protected ReflectionClassDataList() {
     }
 
     @JsonCreator
     ReflectionClassDataList(ArrayList<ReflectionClassData> reflectionClassData,
-                            ArrayList<String> instanceLocations) {
+                            ArrayList<ReflectionClassData> instanceLocations) {
         this.reflectionClassData = reflectionClassData;
-        this.instanceLocations = instanceLocations;
     }
 }

--- a/src/main/java/com/dacubeking/AutoBuilder/robot/serialization/command/SendableCommand.java
+++ b/src/main/java/com/dacubeking/AutoBuilder/robot/serialization/command/SendableCommand.java
@@ -187,6 +187,8 @@ class SendableCommand {
             shouldWait = methodToCall != null && methodToCall.isAnnotationPresent(RequireWait.class);
         }
 
+        shouldWait = shouldWait || AutonomousContainer.getInstance().getRequireWaitObjects().contains(instance);
+
         this.methodToCall = methodToCall;
         this.instance = instance;
         this.shouldWait = shouldWait;


### PR DESCRIPTION
- To do this in a performant manner, we no longer wait for commands to execute before executing future ones. For consistency, this change was also made to methods that looped by returning false.
- A RequireWait annotation was added to mark commands/methods that the AutoBuilder should wait for